### PR TITLE
harfbuzz 10.2.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,21 +18,21 @@ meson setup builddir ^
 	--buildtype=release ^
 	--prefix=%LIBRARY_PREFIX_M% ^
 	--backend=ninja ^
-    -Dglib=enabled ^
-    -Dgobject=enabled ^
-    -Dcairo=enabled ^
-    -Dchafa=disabled ^
-    -Dicu=enabled ^
-    -Dgraphite=enabled ^
-    -Dgraphite2=enabled ^
-    -Dfreetype=enabled ^
-    -Dgdi=enabled ^
-    -Ddirectwrite=disabled ^
-    -Dcoretext=disabled ^
-    -Ddocs=disabled ^
-    -Dtests=enabled ^
-	-Dbenchmark=disabled ^
-	-Dintrospection=enabled
+  -Dbenchmark=disabled ^
+  -Dintrospection=enabled ^
+  -Dcairo=enabled ^
+  -Dchafa=disabled ^
+  -Dcoretext=disabled ^
+  -Ddirectwrite=disabled ^
+  -Ddocs=disabled ^
+  -Dfreetype=enabled ^
+  -Dgdi=enabled ^
+  -Dglib=enabled ^
+  -Dgobject=enabled ^
+  -Dgraphite=disabled ^
+  -Dgraphite2=enabled ^
+  -Dicu=enabled ^
+  -Dtests=enabled
 if errorlevel 1 (
   type src/HarfBuzz-0.0.gir
   exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,10 +12,6 @@ fi
 # the build while this happens.
 find $PREFIX -name '*.la' -delete
 
-if [ "$(uname)" == "Linux" ]; then
-	export CXXFLAGS="${CXXFLAGS//-std=c++17/-std=c++11}"
-fi
-
 
 # necessary to ensure the gobject-introspection-1.0 pkg-config file gets found
 # meson needs this to determine where the g-ir-scanner script is located
@@ -72,17 +68,9 @@ meson setup builddir \
     "${meson_extra_opts[@]}"
 
 ninja -v -C builddir -j ${CPU_COUNT}
-# Debugging
-# 2025-02-04T12:40:32.449927+00:00  | INFO     |     Tag        Type                         Name/Value
-# 2025-02-04T12:40:32.451054+00:00  | INFO     |    0x0000000000000001 (NEEDED)             Shared library: [libharfbuzz.so.0]
-# 2025-02-04T12:40:32.452195+00:00  | INFO     |    0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
-# 2025-02-04T12:40:32.453341+00:00  | INFO     |    0x0000000000000001 (NEEDED)             Shared library: [libcairo.so.2]
-# 2025-02-04T12:40:32.454479+00:00  | INFO     |    0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
-# 2025-02-04T12:40:32.455615+00:00  | INFO     |    0x000000000000000e (SONAME)             Library soname: [libharfbuzz-cairo.so.0]
-# readelf -a $SRC_DIR/builddir/src/libharfbuzz.so
-# readelf -a $SRC_DIR/builddir/src/libharfbuzz-cairo.so
 
 ninja -v -C builddir test
+
 ninja -C builddir install -j ${CPU_COUNT}
 
 pushd "${PREFIX}"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -82,7 +82,7 @@ ninja -v -C builddir -j ${CPU_COUNT}
 # readelf -a $SRC_DIR/builddir/src/libharfbuzz.so
 # readelf -a $SRC_DIR/builddir/src/libharfbuzz-cairo.so
 
-ninja -v -C builddir test
+#ninja -v -C builddir test
 ninja -C builddir install -j ${CPU_COUNT}
 
 pushd "${PREFIX}"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,7 +12,7 @@ fi
 # the build while this happens.
 find $PREFIX -name '*.la' -delete
 
-if [ "${UNAME}" == "Linux" ]; then
+if [ "$(uname)" == "Linux" ]; then
 	export CXXFLAGS="${CXXFLAGS//-std=c++17/-std=c++11}"
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -67,6 +67,9 @@ meson setup builddir \
     "${meson_extra_opts[@]}"
 
 ninja -v -C builddir -j ${CPU_COUNT}
+# Debugging
+readelf -a libharfbuzz-cairo.so
+
 ninja -v -C builddir test
 ninja -C builddir install -j ${CPU_COUNT}
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -82,7 +82,7 @@ ninja -v -C builddir -j ${CPU_COUNT}
 # readelf -a $SRC_DIR/builddir/src/libharfbuzz.so
 # readelf -a $SRC_DIR/builddir/src/libharfbuzz-cairo.so
 
-#ninja -v -C builddir test
+ninja -v -C builddir test
 ninja -C builddir install -j ${CPU_COUNT}
 
 pushd "${PREFIX}"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -59,7 +59,7 @@ meson setup builddir \
     -Dgdi=disabled \
     -Dglib=enabled \
     -Dgobject=enabled \
-    -Dgraphite=disabled \
+    -Dgraphite=enabled \
     -Dgraphite2=enabled \
     -Dicu=enabled \
     -Dintrospection=enabled \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -75,9 +75,7 @@ ninja -v -C builddir -j ${CPU_COUNT}
 # 2025-02-04T12:40:32.454479+00:00  | INFO     |    0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 # 2025-02-04T12:40:32.455615+00:00  | INFO     |    0x000000000000000e (SONAME)             Library soname: [libharfbuzz-cairo.so.0]
 readelf -a $SRC_DIR/builddir/src/libharfbuzz.so
-readelf -a $SRC_DIR/builddir/src/libm.so
 readelf -a $SRC_DIR/builddir/src/libcairo.so
-readelf -a $SRC_DIR/builddir/src/libc.so
 readelf -a $SRC_DIR/builddir/src/libharfbuzz-cairo.so
 
 ninja -v -C builddir test

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -68,7 +68,7 @@ meson setup builddir \
 
 ninja -v -C builddir -j ${CPU_COUNT}
 # Debugging
-readelf -a libharfbuzz-cairo.so
+readelf -a $SRC_DIR/builddir/src/libharfbuzz-cairo.so
 
 ninja -v -C builddir test
 ninja -C builddir install -j ${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,6 +12,11 @@ fi
 # the build while this happens.
 find $PREFIX -name '*.la' -delete
 
+if [ "${UNAME}" == "Linux" ]; then
+	export CXXFLAGS="${CXXFLAGS//-std=c++17/-std=c++11}"
+fi
+
+
 # necessary to ensure the gobject-introspection-1.0 pkg-config file gets found
 # meson needs this to determine where the g-ir-scanner script is located
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:-}:${PREFIX}/lib/pkgconfig:$BUILD_PREFIX/$BUILD/sysroot/usr/lib64/pkgconfig:$BUILD_PREFIX/$BUILD/sysroot/usr/share/pkgconfig

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -68,6 +68,16 @@ meson setup builddir \
 
 ninja -v -C builddir -j ${CPU_COUNT}
 # Debugging
+# 2025-02-04T12:40:32.449927+00:00  | INFO     |     Tag        Type                         Name/Value
+# 2025-02-04T12:40:32.451054+00:00  | INFO     |    0x0000000000000001 (NEEDED)             Shared library: [libharfbuzz.so.0]
+# 2025-02-04T12:40:32.452195+00:00  | INFO     |    0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
+# 2025-02-04T12:40:32.453341+00:00  | INFO     |    0x0000000000000001 (NEEDED)             Shared library: [libcairo.so.2]
+# 2025-02-04T12:40:32.454479+00:00  | INFO     |    0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
+# 2025-02-04T12:40:32.455615+00:00  | INFO     |    0x000000000000000e (SONAME)             Library soname: [libharfbuzz-cairo.so.0]
+readelf -a $SRC_DIR/builddir/src/libharfbuzz.so
+readelf -a $SRC_DIR/builddir/src/libm.so
+readelf -a $SRC_DIR/builddir/src/libcairo.so
+readelf -a $SRC_DIR/builddir/src/libc.so
 readelf -a $SRC_DIR/builddir/src/libharfbuzz-cairo.so
 
 ninja -v -C builddir test

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -79,9 +79,8 @@ ninja -v -C builddir -j ${CPU_COUNT}
 # 2025-02-04T12:40:32.453341+00:00  | INFO     |    0x0000000000000001 (NEEDED)             Shared library: [libcairo.so.2]
 # 2025-02-04T12:40:32.454479+00:00  | INFO     |    0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 # 2025-02-04T12:40:32.455615+00:00  | INFO     |    0x000000000000000e (SONAME)             Library soname: [libharfbuzz-cairo.so.0]
-readelf -a $SRC_DIR/builddir/src/libharfbuzz.so
-readelf -a $SRC_DIR/builddir/src/libcairo.so
-readelf -a $SRC_DIR/builddir/src/libharfbuzz-cairo.so
+# readelf -a $SRC_DIR/builddir/src/libharfbuzz.so
+# readelf -a $SRC_DIR/builddir/src/libharfbuzz-cairo.so
 
 ninja -v -C builddir test
 ninja -C builddir install -j ${CPU_COUNT}

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,0 @@
-cairo:
-  - 1.16
-c_compiler:    # [win]
-  - vs2019     # [win]
-cxx_compiler:  # [win]
-  - vs2019     # [win]

--- a/recipe/disable-check-libstdxx.patch
+++ b/recipe/disable-check-libstdxx.patch
@@ -16,7 +16,7 @@ index b9daabf01..403dfffb0 100644
      dist_check_script += ['check-static-inits', 'check-symbols']
      if get_option('wasm').disabled() and not get_option('with_libstdcxx')
 -      dist_check_script += ['check-libstdc++']
-+      dist_check_script += ['']
++      #dist_check_script += ['check-libstdc++']
      endif
    endif
  

--- a/recipe/disable-check-libstdxx.patch
+++ b/recipe/disable-check-libstdxx.patch
@@ -1,0 +1,25 @@
+From dc55f7b094f88f3b2c98367cb771be7aa31120a1 Mon Sep 17 00:00:00 2001
+From: Serhii Kupriienko
+Date: Tue, 4 Feb 2025 16:43:15 +0200
+Subject: [PATCH] disable the check-libstd++.py test
+
+---
+ src/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/meson.build b/src/meson.build
+index b9daabf01..403dfffb0 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -1033,7 +1033,7 @@ if get_option('tests').enabled()
+   if cpp.get_argument_syntax() != 'msvc' and not meson.is_cross_build() # ensure the local tools are usable
+     dist_check_script += ['check-static-inits', 'check-symbols']
+     if get_option('wasm').disabled() and not get_option('with_libstdcxx')
+-      dist_check_script += ['check-libstdc++']
++      dist_check_script += ['']
+     endif
+   endif
+ 
+-- 
+2.48.0
+

--- a/recipe/fix-win-gir.patch
+++ b/recipe/fix-win-gir.patch
@@ -1,14 +1,19 @@
-Index: harfbuzz-4.3.0/src/meson.build
-===================================================================
---- harfbuzz-4.3.0.orig/src/meson.build
-+++ harfbuzz-4.3.0/src/meson.build
-@@ -667,9 +667,8 @@ if have_gobject
- 
-   if build_gir
+commit c40fb4c192e728d897ca4cf6cc3d6828bbac7597
+Author: Tom Schoonjans <Tom.Schoonjans@rfi.ac.uk>
+Date:   Mon Mar 22 13:38:53 2021 +0000
+
+    Revert "[meson] fix generating introspection"
+    
+    This reverts commit 188ff10aa15af54c4ef10e59bc4e13cea55f7ab4.
+
+diff --git a/src/meson.build b/src/meson.build
+index 4d63ecf..6095093 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -870,7 +870,6 @@ if have_gobject
      conf.set('HAVE_INTROSPECTION', 1)
--    hb_gen_files_gir = gnome.generate_gir(libharfbuzz_gobject,
-+    hb_gen_files_gir = gnome.generate_gir(libharfbuzz, libharfbuzz_gobject,
-       sources: [hb_headers, hb_sources, hb_gobject_headers, hb_gobject_sources, enum_h],
+     hb_gen_files_gir = gnome.generate_gir([libharfbuzz_gobject, libharfbuzz],
+       sources: [gir_headers, gir_sources, gobject_enums_h],
 -      dependencies: libharfbuzz_dep,
        namespace: 'HarfBuzz',
        nsversion: '0.0',

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,10 +26,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ cdt('libxau-devel') }}          # [linux]
-    - {{ cdt('libxext-devel') }}         # [linux]
-    - {{ cdt('libx11-devel') }}          # [linux]
-    - {{ cdt('libxrender-devel') }}      # [linux]
     - {{ cdt('xorg-x11-proto-devel') }}  # [linux and (s390x or ppc64le or x86_64)]; needed for cairo support
     - pkg-config
     - gobject-introspection

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,10 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ cdt('libxau-devel') }}          # [linux]
+    - {{ cdt('libxext-devel') }}         # [linux]
+    - {{ cdt('libx11-devel') }}          # [linux]
+    - {{ cdt('libxrender-devel') }}      # [linux]
     - {{ cdt('xorg-x11-proto-devel') }}  # [linux and (s390x or ppc64le or x86_64)]; needed for cairo support
     - pkg-config
     - gobject-introspection

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,6 @@ build:
     # pretty excellent forward compatibility
     # https://abi-laboratory.pro/index.php?view=timeline&l=harfbuzz
     - {{ pin_subpackage(name, max_pin='x') }}
-  missing_dso_whitelist:      # [linux]
-    - $RPATH/libm.so.6        # [linux]
-    - $RPATH/libc.so.6        # [linux]
-    - $RPATH/libpthread.so.0  # [linux]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    #- {{ compiler('cxx') }}
     - {{ cdt('libxau-devel') }}          # [linux]
     - {{ cdt('libxext-devel') }}         # [linux]
     - {{ cdt('libx11-devel') }}          # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,9 @@ package:
 source:
   url: https://github.com/harfbuzz/harfbuzz/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
-  patches:               # [win]
-    - fix-win-gir.patch  # [win]
+  patches:                          # [win or linux]
+    - fix-win-gir.patch             # [win]
+    - disable-check-libstdxx.patch  # [linux]
 build:
   number: 0
   run_exports:
@@ -21,7 +22,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    #- {{ compiler('cxx') }}
+    - {{ compiler('cxx') }}
+    # CTDs are required for cairo support
     - {{ cdt('libxau-devel') }}          # [linux]
     - {{ cdt('libxext-devel') }}         # [linux]
     - {{ cdt('libx11-devel') }}          # [linux]
@@ -51,8 +53,8 @@ test:
     # Libraries/headers.
     {% set libs = ["harfbuzz-cairo", "harfbuzz-gobject", "harfbuzz-icu", "harfbuzz-subset", "harfbuzz"] %}
     {% for lib in libs %}
-    - test -f $PREFIX/lib/lib{{ lib }}.dylib                         # [osx]
-    - test -f $PREFIX/lib/lib{{ lib }}.so                            # [linux]
+    - test -f $PREFIX/lib/lib{{ lib }}${SHLIB_EXT}                   # [unix]
+    - test -f $PREFIX/lib/pkgconfig/{{ lib }}.pc                     # [unix]
     - if not exist %PREFIX%\Library\bin\{{ lib }}.dll exit 1         # [win]
     {% endfor %}
     - test -f $PREFIX/include/harfbuzz/hb-ft.h                       # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "harfbuzz" %}
-{% set version = "4.3.0" %}
-{% set sha256 = "32184860ddc0b264ff95010e1c64e596bd746fe4c2e34014a1185340cdddeba6" %}
+{% set version = "10.2.0" %}
+{% set sha256 = "11749926914fd488e08e744538f19329332487a6243eec39ef3c63efa154a578" %}
 
 package:
   name: {{ name }}
@@ -12,11 +12,11 @@ source:
   patches:               # [win]
     - fix-win-gir.patch  # [win]
 build:
-  number: 2
+  number: 0
   run_exports:
-    # removes symbols rarely (last time in 2014).
-    #    https://abi-laboratory.pro/tracker/timeline/harfbuzz/
-    - {{ pin_subpackage('harfbuzz') }}
+    # pretty excellent forward compatibility
+    # https://abi-laboratory.pro/index.php?view=timeline&l=harfbuzz
+    - {{ pin_subpackage(name, max_pin='x') }}
   missing_dso_whitelist:      # [linux]
     - $RPATH/libm.so.6        # [linux]
     - $RPATH/libc.so.6        # [linux]
@@ -38,11 +38,11 @@ requirements:
     - pthread-stubs
     - m2-patch  # [win]
   host:
-    - gobject-introspection 1.72.0
-    - cairo 1.16
-    - freetype 2.10
-    - glib 2
-    - icu 73
+    - gobject-introspection 1.78.1
+    - cairo {{ cairo }}
+    - freetype {{ freetype }}
+    - glib {{ glib }}
+    - icu {{ icu }}
     - graphite2 1.3.14
   run:
     - cairo                              # [not win]
@@ -53,18 +53,17 @@ requirements:
 test:
   commands:
     # Libraries/headers.
-    {% set libs = [
-        "harfbuzz-icu",
-        "harfbuzz"
-        ] %}
+    {% set libs = ["harfbuzz-cairo", "harfbuzz-gobject", "harfbuzz-icu", "harfbuzz-subset", "harfbuzz"] %}
     {% for lib in libs %}
-    - test -f $PREFIX/lib/lib{{ lib }}.dylib  # [osx]
-    - test -f $PREFIX/lib/lib{{ lib }}.so  # [linux]
-    - if not exist %PREFIX%\Library\bin\{{ lib }}.dll exit 1 # [win]
+    - test -f $PREFIX/lib/lib{{ lib }}.dylib                         # [osx]
+    - test -f $PREFIX/lib/lib{{ lib }}.so                            # [linux]
+    - if not exist %PREFIX%\Library\bin\{{ lib }}.dll exit 1         # [win]
     {% endfor %}
-    - test -f $PREFIX/include/harfbuzz/hb-ft.h  # [not win]
-    - if not exist %PREFIX%\Library\include\harfbuzz\hb-ft.h exit 1 # [win]
-    - test -f $PREFIX/share/gir-1.0/HarfBuzz-0.0.gir  # [not win]
+    - test -f $PREFIX/include/harfbuzz/hb-ft.h                       # [not win]
+    - if not exist %PREFIX%\Library\include\harfbuzz\hb-ft.h exit 1  # [win]
+    - test -f $PREFIX/lib/girepository-1.0/HarfBuzz-0.0.typelib      # [unix]
+    - if not exist %PREFIX%\Library\lib\girepository-1.0\HarfBuzz-0.0.typelib exit 1  # [win]
+    - test -f $PREFIX/share/gir-1.0/HarfBuzz-0.0.gir                 # [not win]
     # CLI tests.
     - hb-view --version  # [linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,10 @@ source:
   sha256: {{ sha256 }}
   patches:                          # [win or linux]
     - fix-win-gir.patch             # [win]
+    # check-libstdc++.py fails on linux with a message
+    # 'Ouch, $SRC_DIR/builddir/src/libharfbuzz-cairo.so is linked to libstdc++ or libc++',
+    # but checking by 'readelf -a $SRC_DIR/builddir/src/libharfbuzz-cairo.so' it was verified
+    # that there are no linking to ibstdc++ or libc++. So skipping the test.
     - disable-check-libstdxx.patch  # [linux]
 build:
   number: 0
@@ -35,6 +39,7 @@ requirements:
     - ninja-base
     - pthread-stubs
     - m2-patch  # [win]
+    - patch     # [linux]
   host:
     - gobject-introspection 1.78.1
     - cairo {{ cairo }}

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,7 @@
+import gi
+gi.require_version('HarfBuzz', '0.0')
+from gi.repository import HarfBuzz as hb
+import sys
+
+if hb.buffer_create () is None:
+    sys.exit(1)

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,7 +1,0 @@
-import gi
-gi.require_version('HarfBuzz', '0.0')
-from gi.repository import HarfBuzz as hb
-import sys
-
-if hb.buffer_create () is None:
-    sys.exit(1)


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-2234](https://anaconda.atlassian.net/browse/PKG-2234) 
- [Upstream repository](https://github.com/harfbuzz/harfbuzz/tree/10.2.0)
- Requirements:
  - https://github.com/harfbuzz/harfbuzz/blob/10.2.0/meson.build
  - https://github.com/harfbuzz/harfbuzz/blob/10.2.0/meson_options.txt
  - https://github.com/harfbuzz/harfbuzz/blob/10.2.0/src/meson.build
  - https://github.com/harfbuzz/harfbuzz/blob/10.2.0/BUILD.md
  - https://github.com/harfbuzz/harfbuzz/blob/10.2.0/CONFIG.md

### Explanation of changes:

- Update `meson setup` flags in `bld.bat` and `build.sh`
- Add `XDG_DATA_DIRS` on `unix` and `LDFLAGS` & `LDFLAGS_LD` on `osx`, see comments in `build.sh`
- Remove an obsolete local `cbc.yaml`
- Add a patch to disable the `check-libstd++.py` test because it mistakenly says that `$SRC_DIR/builddir/src/libharfbuzz-cairo.so` is linked to `libstdc++` or `libc++`. 
- Refresh `fix-win-gir.patch`
- Reset the build number to `0`
- Remove `missing_dso_whitelist`
- Update `run_exports` to pin to a major version (based on the conda-forge recipe)
- Add a comment about CTDs being required for cairo support
- Update pinnings in `host`
- Add more test commands

### Notes:

- Updating because `harfbuzz <7.0.0` are impacted by CVE-2023-25193 with a score of 7.5
- We must rebuild downstream packages, see https://metayaml-conda.fly.dev/metayaml/reverse_dependencies?name=harfbuzz or `ddb get-impact harfbuzz 10.2.0 | jq -r -c ".[][] | [.name, .depends_on, .channel]"`

```
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["opencv","harfbuzz >=4.3.0,<5.0a0","main"]
["librsvg","harfbuzz >=4.3.0,<5.0a0","main"]
["librsvg","harfbuzz >=4.3.0,<5.0a0","main"]
["librsvg","harfbuzz >=4.3.0,<5.0a0","main"]
["librsvg","harfbuzz >=4.3.0,<5.0a0","main"]
["librsvg","harfbuzz >=4.3.0,<5.0a0","main"]
["gtk3","harfbuzz >=4.3.0,<5.0a0","main"]
["gtk3","harfbuzz >=4.3.0,<5.0a0","main"]
["ffmpeg","harfbuzz >=4.3.0,<5.0a0","main"]
["ffmpeg","harfbuzz >=4.3.0,<5.0a0","main"]
["ffmpeg","harfbuzz >=4.3.0,<5.0a0","main"]
["ffmpeg","harfbuzz >=4.3.0,<5.0a0","main"]
["ffmpeg","harfbuzz >=4.3.0,<5.0a0","main"]
["ffmpeg","harfbuzz >=4.3.0,<5.0a0","main"]
["pango","harfbuzz >=2.6.0","main"]
["pango","harfbuzz >=2.6.0","main"]
["pango","harfbuzz >=2.6.0","main"]
["pango","harfbuzz >=2.6.0","main"]
["pango","harfbuzz >=2.6.0","main"]
["pango","harfbuzz >=2.6.0","main"]
["opencv-suite","harfbuzz >=2.8.1,<3.0a0","main"]
["texlive-core","harfbuzz >=1.7.6,<2.0a0","main"]
["texlive-core","harfbuzz >=1.7.6,<2.0a0","main"]
["opencv-python-headless","harfbuzz >=4.3.0,<5.0a0","sfe1ed40"]
["opencv-python-headless","harfbuzz >=4.3.0,<5.0a0","sfe1ed40"]
["opencv-python-headless","harfbuzz >=4.3.0,<5.0a0","sfe1ed40"]
["opencv-python-headless","harfbuzz >=4.3.0,<5.0a0","sfe1ed40"]
["opencv-python-headless","harfbuzz >=4.3.0,<5.0a0","sfe1ed40"]
["opencv-python-headless","harfbuzz >=4.3.0,<5.0a0","sfe1ed40"]
["opencv-python-headless","harfbuzz >=4.3.0,<5.0a0","sfe1ed40"]
["opencv-python-headless","harfbuzz >=4.3.0,<5.0a0","sfe1ed40"]
["opencv-python-headless","harfbuzz >=4.3.0,<5.0a0","sfe1ed40"]
["opencv-python-headless","harfbuzz >=4.3.0,<5.0a0","sfe1ed40"]
["opencv-python-headless","harfbuzz >=4.3.0,<5.0a0","sfe1ed40"]
["opencv-python-headless","harfbuzz >=4.3.0,<5.0a0","sfe1ed40"]

```
[PKG-2234]: https://anaconda.atlassian.net/browse/PKG-2234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ